### PR TITLE
Add infra-nodes to the cluster

### DIFF
--- a/security_groups.tf
+++ b/security_groups.tf
@@ -131,12 +131,12 @@ resource "exoscale_security_group_rules" "control_plane" {
   }
 }
 
-resource "exoscale_security_group" "worker" {
-  name        = "${var.cluster_id}_worker"
-  description = "${var.cluster_id} worker nodes"
+resource "exoscale_security_group" "infra" {
+  name        = "${var.cluster_id}_infra"
+  description = "${var.cluster_id} infra nodes"
 }
-resource "exoscale_security_group_rules" "worker" {
-  security_group = exoscale_security_group.worker.name
+resource "exoscale_security_group_rules" "infra" {
+  security_group = exoscale_security_group.infra.name
   ingress {
     description              = "Ingress controller TCP"
     protocol                 = "TCP"

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,11 @@ variable "worker_count" {
   default = 3
 }
 
+variable "infra_count" {
+  type    = number
+  default = 3
+}
+
 variable "master_count" {
   type    = number
   default = 3
@@ -59,6 +64,11 @@ variable "worker_size" {
   default = "Extra-large"
 }
 
+variable "infra_size" {
+  type    = string
+  default = "Extra-large"
+}
+
 variable "bootstrap_state" {
   type    = string
   default = "Running"
@@ -70,6 +80,11 @@ variable "master_state" {
 }
 
 variable "worker_state" {
+  type    = string
+  default = "Running"
+}
+
+variable "infra_state" {
   type    = string
   default = "Running"
 }


### PR DESCRIPTION
Infra nodes are special compute nodes that only accept infrastructure services, e.g. router, monitoring etc.