### PR TITLE
Use open-source version of Ursula (Floaty)

### DIFF
--- a/files/keepalived-notify-script
+++ b/files/keepalived-notify-script
@@ -3,8 +3,8 @@
 
 set -e -u -o pipefail
 
-ursula_bin=/usr/bin/ursula
-log_name=keepalived-ursula-eth1
-config_file=/etc/ursula/config.yaml
+floaty_bin=/usr/bin/floaty
+log_name=keepalived-floaty-eth1
+config_file=/etc/floaty/config.yaml
 
-"$ursula_bin" "$config_file" "$@" 2>&1 | logger --tag "$log_name"
+"$floaty_bin" "$config_file" "$@" 2>&1 | logger --tag "$log_name"

--- a/lb.tf
+++ b/lb.tf
@@ -88,16 +88,16 @@ resource "exoscale_compute" "lb" {
         ))
       },
       {
-        "path"        = "/etc/ursula/eth1.wrapper",
+        "path"        = "/etc/floaty/eth1.wrapper",
         "encoding"    = "b64",
         "content"     = filebase64("${path.module}/files/keepalived-notify-script"),
         "permissions" = "0755"
       },
       {
-        "path"     = "/etc/ursula/config.yaml",
+        "path"     = "/etc/floaty/config.yaml",
         "encoding" = "b64",
         "content" = base64encode(templatefile(
-          "${path.module}/templates/ursula.yaml.tmpl",
+          "${path.module}/templates/floaty.yaml.tmpl",
           {
             "api_key"    = var.lb_exoscale_api_key
             "api_secret" = var.lb_exoscale_api_secret
@@ -126,8 +126,8 @@ resource "exoscale_compute" "lb" {
     ],
     "runcmd" = [
       "while lsof -F p /var/lib/dpkg/lock 2>/dev/null; do echo \"Waiting for dpkg lock...\"; sleep 15; done",
-      "curl -Lo /tmp/ursula.deb ${trimsuffix(var.bootstrap_bucket, "/")}/ursula.deb",
-      "dpkg -i /tmp/ursula.deb",
+      "curl -Lo /tmp/floaty.deb https://github.com/vshn/floaty/releases/latest/download/floaty_linux_amd64.deb",
+      "dpkg -i /tmp/floaty.deb",
       "systemctl restart keepalived",
       "shutdown --reboot +1 'Reboot for system setup'"
     ]

--- a/templates/floaty.yaml.tmpl
+++ b/templates/floaty.yaml.tmpl
@@ -5,7 +5,7 @@ cloudscale:
 exoscale:
   key: ${api_key}
   secret: ${api_secret}
-lock-file-template: "/var/run/keepalived.ursula.%s.lock"
+lock-file-template: "/var/run/keepalived.floaty.%s.lock"
 managed-addresses:
 %{for addr in managed_addrs ~}
 - ${addr}

--- a/templates/keepalived.conf.tmpl
+++ b/templates/keepalived.conf.tmpl
@@ -9,7 +9,7 @@ vrrp_instance eth1 {
   garp_master_refresh         30
 
 
-  notify /etc/ursula/eth1.wrapper
+  notify /etc/floaty/eth1.wrapper
 
 
   authentication {
@@ -31,4 +31,3 @@ vrrp_instance eth1 {
     ${peer_ip}
   }
 }
-


### PR DESCRIPTION
* replaces occurrences of `Ursula` with `Floaty`
* Downloads a tagged public release from GitHub (instead from bootstrap bucket)