### PR TITLE
Configure default node disk size to match product description

### DIFF
--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -26,7 +26,12 @@ variable "instance_size" {
 
 variable "disk_size" {
   type    = number
-  default = 128
+  default = 120
+
+  validation {
+    condition     = var.disk_size >= 120
+    error_message = "The minimum supported disk size for OCP4 is 120GB."
+  }
 }
 
 variable "template_id" {


### PR DESCRIPTION
Product documentation: https://products.docs.vshn.ch/products/appuio/managed/ocp4_exoscale.html#_default_configuration_minimum_requirements

Also throw a validation error when users try to create nodes with less than 120GB disk, as that's the minimum supported disk size for OCP4, cf. the [OCP4 documentation].

[OCP4 documentation]: https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal