### PR TITLE
Disable register_lb refresh trigger when shell script changes

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -82,8 +82,9 @@ data "exoscale_compute_template" "ubuntu2004" {
 
 resource "null_resource" "register_lb" {
   triggers = {
-    # Refresh resource when script changes -- this is probaby not required for production
-    script_sha1 = filesha1("${path.module}/files/register-server.sh")
+    # Refresh resource when the script changes -- this is probaby not required for production
+    # Uncomment this trigger if you want to test changes to `files/register-server.sh`
+    # script_sha1 = filesha1("${path.module}/files/register-server.sh")
     # Refresh resource when lb fqdn changes
     lb_id = local.instance_fqdns[count.index]
   }


### PR DESCRIPTION
There's no reason to keep the refresh trigger when the shell script is changed for the `register_lb` resource.

This only leads to unnecessary (and potentially dangerous) changes for already provisioned clusters. The only reason a productive cluster needs to refresh the `register_lb` resource is when the LB names change and the new LBs need to be registered at VSHN.