### PR TITLE
Add support for configuring node disk sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The module provides variables to
   Note that we don't recommend changing the count for the LBs and masters from their default values.
 * control the size of the root partition for all nodes.
   This value is used for all nodes and cannot be customized for individual node groups.
-* control the total disk size for master, infra, and worker nodes.
-  Terraform emits an error if the total disk size of a node group is smaller than the root disk size.
-  If the total disk size for a node group is bigger than the root disk size, the module configures the nodes to have an additional empty partition for the remaining disk.
+* control the size of the empty partition on worker nodes.
+  By default, worker nodes are provisioned without an empty partition (by defaulting the variable to 0)
+  However, users can create worker nodes with an empty partition by providing a positive value for the variable.
 * control the size of the empty partition on the storage nodes.
   This partition can be used as backing storage by in-cluster storage clusters, such as Rook-Ceph.
 * configure additional worker node groups.
-  This variable is a map from worker group names (used as node prefixes) to objects providing node instance size, node count, node disk size, and node state.
+  This variable is a map from worker group names (used as node prefixes) to objects providing node instance size, node count, node data disk size, and node state.
 * specify the cluster's id, Exoscale region, base domain, SSH key, RHCOS template, and Ignition API CA.
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
 * specify an Exoscale API key and secret for Floaty
@@ -68,7 +68,7 @@ module "cluster" {
 }
 ```
 
-To configure an additional worker group named "storage1" with 3 instances with type "Storage-huge", and 5120GB of total disk size, the following input can be given:
+To configure an additional worker group named "storage1" with 3 instances with type "Storage-huge", and 5120GB of total disk size (120GB root disk + 5000GB data disk), the following input can be given:
 
 ```terraform
 # File main.tf
@@ -79,7 +79,7 @@ module "cluster" {
     "storage1": {
       size: "Storage-huge"
       count: 3
-      disk_size: 5120
+      data_disk_size: 5000
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The module provides variables to
   Note that we don't officially support smaller instance sizes than the ones provided as defaults.
 * control the count of each VM type (LB, bootstrap, master, infra, storage, and worker).
   Note that we don't recommend changing the count for the LBs and masters from their default values.
+* control the size of the root partition for all nodes.
+  This value is used for all nodes and cannot be customized for individual node groups.
+* control the total disk size for master, infra, and worker nodes.
+  Terraform emits an error if the total disk size of a node group is smaller than the root disk size.
+  If the total disk size for a node group is bigger than the root disk size, the module configures the nodes to have an additional empty partition for the remaining disk.
 * control the size of the empty partition on the storage nodes.
   This partition can be used as backing storage by in-cluster storage clusters, such as Rook-Ceph.
 * configure additional worker node groups.
@@ -44,7 +49,7 @@ The module provides variables to
 Please note that you cannot use names "master", "infra", "worker" or "storage" for additional worker groups.
 We prohibit these names to ensure there are no collisions between the generated nodes names for different worker groups.
 
-As the example shows, attributes `disk_size` and `state` for entries in `additional_worker_groups` are optional.
+As the examples show, attributes `disk_size` and `state` for entries in `additional_worker_groups` are optional.
 If these attributes are not given, the nodes are deployed with `disk_size = var.root_disk_size` and `state = "Running"`
 
 To configure an additional worker group named "cpu1" with 3 instances with type "CPU-huge" the following input can be given:
@@ -58,6 +63,23 @@ module "cluster" {
     "cpu1": {
       size: "CPU-huge"
       count: 3
+    }
+  }
+}
+```
+
+To configure an additional worker group named "storage1" with 3 instances with type "Storage-huge", and 5120GB of total disk size, the following input can be given:
+
+```terraform
+# File main.tf
+module "cluster" {
+  // Remaining config for module omitted
+
+  additional_worker_groups = {
+    "storage1": {
+      size: "Storage-huge"
+      count: 3
+      disk_size: 5120
     }
   }
 }

--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -12,7 +12,6 @@ module "bootstrap" {
   template_id   = data.exoscale_compute_template.rhcos.id
   base_domain   = var.base_domain
   instance_size = "Extra-large"
-  disk_size     = 128
   node_state    = var.bootstrap_state
   ssh_key_pair  = local.ssh_key_name
 

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -12,7 +12,6 @@ module "master" {
   ssh_key_pair  = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
-  data_disk_size = var.master_disk_size - var.root_disk_size
 
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -11,6 +11,9 @@ module "master" {
   node_state    = var.master_state
   ssh_key_pair  = local.ssh_key_name
 
+  root_disk_size = var.root_disk_size
+  data_disk_size = var.master_disk_size - var.root_disk_size
+
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""
   privnet_gw  = local.privnet_gw

--- a/infra.tf
+++ b/infra.tf
@@ -12,7 +12,6 @@ module "infra" {
   ssh_key_pair  = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
-  data_disk_size = var.infra_disk_size - var.root_disk_size
 
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""

--- a/infra.tf
+++ b/infra.tf
@@ -11,6 +11,9 @@ module "infra" {
   node_state    = var.infra_state
   ssh_key_pair  = local.ssh_key_name
 
+  root_disk_size = var.root_disk_size
+  data_disk_size = var.infra_disk_size - var.root_disk_size
+
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""
   privnet_gw  = local.privnet_gw

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -24,15 +24,26 @@ variable "instance_size" {
   default = "Extra-large"
 }
 
-variable "disk_size" {
+variable "root_disk_size" {
   type    = number
   default = 120
 
   validation {
-    condition     = var.disk_size >= 120
-    error_message = "The minimum supported disk size for OCP4 is 120GB."
+    condition     = var.root_disk_size >= 120
+    error_message = "The minimum supported root disk size for OCP4 is 120GB."
   }
 }
+
+variable "data_disk_size" {
+  type    = number
+  default = 0
+
+  validation {
+    condition     = var.data_disk_size >= 0
+    error_message = "Creating a data disk with size < 0 is not possible."
+  }
+}
+
 
 variable "template_id" {
   type = string
@@ -90,6 +101,6 @@ variable "storage_disk_size" {
   validation {
     # minimum TBD
     condition     = var.storage_disk_size == 0 || var.storage_disk_size >= 180
-    error_message = "The minimum supported storage disk size is 180GB."
+    error_message = "The minimum supported storage cluster disk size is 180GB."
   }
 }

--- a/storage.tf
+++ b/storage.tf
@@ -11,7 +11,12 @@ module "storage" {
   node_state    = var.storage_state
   ssh_key_pair  = local.ssh_key_name
 
-  storage_disk_size = var.storage_disk_size
+  root_disk_size = var.root_disk_size
+
+  // We never configure a data disk for storage cluster nodes
+  // Instead, we keep the `storage_disk_size` special case to provision
+  // dedicated storage cluster nodes for now.
+  storage_disk_size = var.storage_cluster_disk_size
 
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""

--- a/variables.tf
+++ b/variables.tf
@@ -104,12 +104,52 @@ variable "storage_state" {
   default = "Running"
 }
 
-variable "storage_disk_size" {
+variable "root_disk_size" {
+  type    = number
+  default = 120
+
+  validation {
+    condition     = var.root_disk_size >= 120
+    error_message = "The minimum supported root disk size is 120GB."
+  }
+}
+
+variable "master_disk_size" {
+  type    = number
+  default = 120
+
+  validation {
+    condition     = var.master_disk_size >= 120
+    error_message = "The minimum supported master disk size is 120GB."
+  }
+}
+
+variable "worker_disk_size" {
+  type    = number
+  default = 120
+
+  validation {
+    condition     = var.worker_disk_size >= 120
+    error_message = "The minimum supported worker disk size is 120GB."
+  }
+}
+
+variable "infra_disk_size" {
+  type    = number
+  default = 120
+
+  validation {
+    condition     = var.infra_disk_size >= 120
+    error_message = "The minimum supported infra disk size is 120GB."
+  }
+}
+
+variable "storage_cluster_disk_size" {
   type    = number
   default = 180
 
   validation {
-    condition     = var.storage_disk_size >= 180
+    condition     = var.storage_cluster_disk_size >= 180
     error_message = "The minimum supported storage disk size is 180GB."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -114,33 +114,13 @@ variable "root_disk_size" {
   }
 }
 
-variable "master_disk_size" {
+variable "worker_data_disk_size" {
   type    = number
-  default = 120
+  default = 0
 
   validation {
-    condition     = var.master_disk_size >= 120
-    error_message = "The minimum supported master disk size is 120GB."
-  }
-}
-
-variable "worker_disk_size" {
-  type    = number
-  default = 120
-
-  validation {
-    condition     = var.worker_disk_size >= 120
-    error_message = "The minimum supported worker disk size is 120GB."
-  }
-}
-
-variable "infra_disk_size" {
-  type    = number
-  default = 120
-
-  validation {
-    condition     = var.infra_disk_size >= 120
-    error_message = "The minimum supported infra disk size is 120GB."
+    condition     = var.worker_data_disk_size >= 0
+    error_message = "The worker data disk size cannot be negative."
   }
 }
 
@@ -150,12 +130,12 @@ variable "storage_cluster_disk_size" {
 
   validation {
     condition     = var.storage_cluster_disk_size >= 180
-    error_message = "The minimum supported storage disk size is 180GB."
+    error_message = "The minimum supported storage cluster disk size is 180GB."
   }
 }
 
 variable "additional_worker_groups" {
-  type    = map(object({ size = string, count = number, disk_size = optional(number), state = optional(string) }))
+  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string) }))
   default = {}
 
   validation {
@@ -163,13 +143,13 @@ variable "additional_worker_groups" {
       for k, v in var.additional_worker_groups :
       !contains(["worker", "master", "infra", "storage"], k) &&
       v.count > 0 &&
-      (v.disk_size != null ? v.disk_size >= 120 : true) &&
+      (v.data_disk_size != null ? v.data_disk_size >= 0 : true) &&
       (v.state == null || v.state == "Running" || v.state == "Stopped")
     ])
     // Cannot use any of the nicer string formatting options because
     // error_message validation is dumb, cf.
     // https://github.com/hashicorp/terraform/issues/24123
-    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The minimum supported disk size for workers is 120GB.\n * Additional worker group names cannot be 'worker', 'master', 'infra', or 'storage'.\n * The only valid worker states are 'Running' or 'Stopped'.\n * The worker count cannot be less than 0."
+    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The worker data disk size cannot be negative.\n * Additional worker group names cannot be 'worker', 'master', 'infra', or 'storage'.\n * The only valid worker states are 'Running' or 'Stopped'.\n * The worker count cannot be less than 0."
   }
 }
 

--- a/worker.tf
+++ b/worker.tf
@@ -14,7 +14,7 @@ module "worker" {
   ssh_key_pair  = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
-  data_disk_size = var.worker_disk_size - var.root_disk_size
+  data_disk_size = var.worker_data_disk_size
 
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""
@@ -47,7 +47,7 @@ module "additional_worker" {
 
   root_disk_size = var.root_disk_size
   // Default data disk size to 0 if map entry doesn't have field disk_size
-  data_disk_size = each.value.disk_size != null ? each.value.disk_size - var.root_disk_size : 0
+  data_disk_size = each.value.data_disk_size != null ? each.value.data_disk_size : 0
 
   region       = var.region
   template_id  = data.exoscale_compute_template.rhcos.id

--- a/worker.tf
+++ b/worker.tf
@@ -1,5 +1,5 @@
 // Default worker group.
-// Configured from var.worker_{count,size,state}
+// Configured from var.worker_{count,size,state,disk_size}
 module "worker" {
   source = "./modules/node-group"
 
@@ -12,6 +12,9 @@ module "worker" {
   instance_size = var.worker_size
   node_state    = var.worker_state
   ssh_key_pair  = local.ssh_key_name
+
+  root_disk_size = var.root_disk_size
+  data_disk_size = var.worker_disk_size - var.root_disk_size
 
   use_privnet = var.use_privnet
   privnet_id  = var.use_privnet ? exoscale_network.clusternet.id : ""
@@ -41,8 +44,10 @@ module "additional_worker" {
   instance_size = each.value.size
   // Default node_state to "Running" if not specified in map entry
   node_state = each.value.state != null ? each.value.state : "Running"
-  // Default disk size to 120GB if map entry doesn't have field disk_size
-  disk_size = each.value.disk_size != null ? each.value.disk_size : 120
+
+  root_disk_size = var.root_disk_size
+  // Default data disk size to 0 if map entry doesn't have field disk_size
+  data_disk_size = each.value.disk_size != null ? each.value.disk_size - var.root_disk_size : 0
 
   region       = var.region
   template_id  = data.exoscale_compute_template.rhcos.id


### PR DESCRIPTION
This PR introduces variables to control the size of all node disks.

The PR introduces a variable `root_disk_size` which can be used to configure the size of the root disk of all nodes and a variable `worker_data_disk_size` which can be used to configure an additional data partition on worker nodes. Field `data_disk_size` for entries in `additional_worker_groups` can be used to configure a data partition on additional worker nodes.

**TODO**

- [x] Rebase after #16 and #18 have been merged