### PR TITLE
Add support for configuring additional affinity group IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The module provides variables to
   This partition can be used as backing storage by in-cluster storage clusters, such as Rook-Ceph.
 * configure additional worker node groups.
   This variable is a map from worker group names (used as node prefixes) to objects providing node instance size, node count, node data disk size, and node state.
+* configure additional affinity group IDs which are configured on all master, infra, storage, and worker VMs
+  This allows users to configure pre-existing affinity groups (e.g. for Exoscale dedicated VM hosts) for the cluster
 * specify the cluster's id, Exoscale region, base domain, SSH key, RHCOS template, and Ignition API CA.
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
 * specify an Exoscale API key and secret for Floaty

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -25,6 +25,8 @@ module "master" {
     exoscale_security_group.control_plane.id,
   ]
 
+  additional_affinity_group_ids = var.additional_affinity_group_ids
+
   bootstrap_bucket = var.bootstrap_bucket
 }
 

--- a/infra.tf
+++ b/infra.tf
@@ -25,6 +25,8 @@ module "infra" {
     exoscale_security_group.infra.id,
   ]
 
+  additional_affinity_group_ids = var.additional_affinity_group_ids
+
   bootstrap_bucket = var.bootstrap_bucket
 }
 

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -142,18 +142,22 @@ resource "exoscale_affinity" "anti_affinity_group" {
 }
 
 resource "exoscale_compute" "nodes" {
-  count              = var.node_count
-  display_name       = "${random_id.node_id[count.index].hex}.${var.cluster_id}.${var.base_domain}"
-  hostname           = random_id.node_id[count.index].hex
-  key_pair           = var.ssh_key_pair
-  zone               = var.region
-  affinity_group_ids = [exoscale_affinity.anti_affinity_group[0].id]
-  template_id        = var.template_id
-  size               = var.instance_size
-  disk_size          = local.disk_size
+  count        = var.node_count
+  display_name = "${random_id.node_id[count.index].hex}.${var.cluster_id}.${var.base_domain}"
+  hostname     = random_id.node_id[count.index].hex
+  key_pair     = var.ssh_key_pair
+  zone         = var.region
+  template_id  = var.template_id
+  size         = var.instance_size
+  disk_size    = local.disk_size
+  user_data    = local.user_data
+  state        = var.node_state
+
   security_group_ids = var.security_group_ids
-  user_data          = local.user_data
-  state              = var.node_state
+  affinity_group_ids = concat(
+    [exoscale_affinity.anti_affinity_group[0].id],
+    var.additional_affinity_group_ids
+  )
 
   lifecycle {
     ignore_changes = [

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -104,3 +104,9 @@ variable "storage_disk_size" {
     error_message = "The minimum supported storage cluster disk size is 180GB."
   }
 }
+
+variable "additional_affinity_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of additional affinity group IDs to configure on all nodes"
+}

--- a/storage.tf
+++ b/storage.tf
@@ -30,5 +30,7 @@ module "storage" {
     exoscale_security_group.storage.id,
   ]
 
+  additional_affinity_group_ids = var.additional_affinity_group_ids
+
   bootstrap_bucket = var.bootstrap_bucket
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,12 @@ variable "additional_worker_groups" {
   }
 }
 
+variable "additional_affinity_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of additional affinity group IDs to configure on all nodes"
+}
+
 variable "ignition_ca" {
   type = string
 }

--- a/worker.tf
+++ b/worker.tf
@@ -27,6 +27,8 @@ module "worker" {
     exoscale_security_group.all_machines.id,
   ]
 
+  additional_affinity_group_ids = var.additional_affinity_group_ids
+
   bootstrap_bucket = var.bootstrap_bucket
 }
 
@@ -64,6 +66,8 @@ module "additional_worker" {
   security_group_ids = [
     exoscale_security_group.all_machines.id,
   ]
+
+  additional_affinity_group_ids = var.additional_affinity_group_ids
 
   bootstrap_bucket = var.bootstrap_bucket
 }


### PR DESCRIPTION
This allows users to configure pre-existing affinity groups for all cluster VMs (except the bootstrap node). This can be useful for example when wanting to deploy Exoscale VMs on dedicated VM hosts.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
