### PR TITLE
Add support for configuring additional affinity groups in `additional_worker_groups`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The module provides variables to
 Please note that you cannot use names "master", "infra", "worker" or "storage" for additional worker groups.
 We prohibit these names to ensure there are no collisions between the generated nodes names for different worker groups.
 
-As the examples show, attributes `disk_size` and `state` for entries in `additional_worker_groups` are optional.
-If these attributes are not given, the nodes are deployed with `disk_size = var.root_disk_size` and `state = "Running"`
+As the examples show, attributes `disk_size`, `state` and `affinity_group_ids` for entries in `additional_worker_groups` are optional.
+If these attributes are not given, the nodes are deployed with `disk_size = var.root_disk_size`, `state = "Running"` and `affinity_group_ids = []`.
 
 To configure an additional worker group named "cpu1" with 3 instances with type "CPU-huge" the following input can be given:
 

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "storage_cluster_disk_size" {
 }
 
 variable "additional_worker_groups" {
-  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string) }))
+  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string), affinity_group_ids = list(string) }))
   default = {}
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "storage_cluster_disk_size" {
 }
 
 variable "additional_worker_groups" {
-  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string), affinity_group_ids = list(string) }))
+  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string), affinity_group_ids = optional(list(string)) }))
   default = {}
 
   validation {

--- a/worker.tf
+++ b/worker.tf
@@ -68,7 +68,7 @@ module "additional_worker" {
   ]
 
   additional_affinity_group_ids = concat(
-    each.affinity_group_ids,
+    each.value.affinity_group_ids != null ? each.value.affinity_group_ids : [],
     var.additional_affinity_group_ids
   )
 

--- a/worker.tf
+++ b/worker.tf
@@ -67,7 +67,10 @@ module "additional_worker" {
     exoscale_security_group.all_machines.id,
   ]
 
-  additional_affinity_group_ids = var.additional_affinity_group_ids
+  additional_affinity_group_ids = concat(
+    each.affinity_group_ids,
+    var.additional_affinity_group_ids
+  )
 
   bootstrap_bucket = var.bootstrap_bucket
 }


### PR DESCRIPTION
Each additional worker group has the possibility to be assigned to a special affinity group
so Exoscale can shedule them on dedicated hardware.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
