### PR TITLE
Provide location for MR URL file to commit script

### DIFF
--- a/files/commit-hieradata.sh
+++ b/files/commit-hieradata.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-readonly cluster_id=$1
+readonly cluster_id="$1"
+readonly mr_url_file="$2"
 readonly branch="tf/lbaas/${cluster_id}"
 
 cd appuio_hieradata || exit 1
@@ -72,4 +73,4 @@ else
   mr_url=$(echo "${open_mrs}" | jq -r '.[0].web_url')
 fi
 
-echo "${mr_url}" > /tf/.mr_url.txt
+echo "${mr_url}" > "${mr_url_file}"

--- a/lb.tf
+++ b/lb.tf
@@ -151,7 +151,7 @@ resource "local_file" "lb_hieradata" {
   ]
 
   provisioner "local-exec" {
-    command = "${path.module}/files/commit-hieradata.sh ${var.cluster_id}"
+    command = "${path.module}/files/commit-hieradata.sh ${var.cluster_id} ${path.cwd}/.mr_url.txt"
   }
 }
 


### PR DESCRIPTION
The `commit-hieradata.sh` script previously had hard-coded location `/tf/.mr_url.txt` to write the URL of the hieradata MR, if any.

This doesn't work in GitLab CI, as the directory structure looks different to the structure we have during cluster setup.

This commit extends the `commit-hieradata.sh` script to take the full path to the `.mr_url.txt` file as a second parameter on the command line and updates the Terraform code to provide the path to the script.

With this change, we can use Terraform's `${path.cwd}` to always create the `.mr_url.txt` file in Terraform's working directory.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
