### PR TITLE
Update zero_storagepool service to start on 4.8

### DIFF
--- a/modules/node-group/templates/zero_storagepool.service.tmpl
+++ b/modules/node-group/templates/zero_storagepool.service.tmpl
@@ -7,7 +7,7 @@ ConditionPathExists=/run/ostree-booted
 ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
 # Use same conditions as for machine-config-daemon-firstboot.service
 After=machine-config-daemon-pull.service
-Before=crio.service crio-wipe.service
+Before=crio.service
 Before=kubelet.service
 
 [Service]


### PR DESCRIPTION
With ocp 4.8 there seems to be a slight change in systemd service dependencies. This will cause our zero storagepool service to not start, which will further block kubelet and prevent the storage node to start.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
