### PR TITLE
Introduce separate variable `cluster_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@ The module provides variables to
   This variable is a map from worker group names (used as node prefixes) to objects providing node instance size, node count, node data disk size, and node state.
 * configure additional affinity group IDs which are configured on all master, infra, storage, and worker VMs
   This allows users to configure pre-existing affinity groups (e.g. for Exoscale dedicated VM hosts) for the cluster
-* specify the cluster's id, Exoscale region, base domain, SSH key, RHCOS template, and Ignition API CA.
+* specify the cluster's id, name (optional), Exoscale region, base domain, SSH key, RHCOS template, and Ignition API CA.
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
 * specify an Exoscale API key and secret for Floaty
 * specify the username for the APPUiO hieradata Git repository (see next sections for details).
 * provide an API token for control.vshn.net (see next sections for details).
+
+The cluster's domain is constructed from the provided base domain, cluster id and cluster name.
+If a cluster name is provided the cluster domain is set to `<cluster name>.<base domain>`.
+Otherwise the cluster domain is set to `<cluster id>.<base domain>`.
 
 ## Configuring additional worker groups
 

--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -5,15 +5,16 @@ locals {
 module "bootstrap" {
   source = "./modules/node-group/"
 
-  cluster_id    = var.cluster_id
-  role          = "bootstrap"
-  node_count    = var.bootstrap_count
-  region        = var.region
-  template_id   = data.exoscale_compute_template.rhcos.id
-  base_domain   = var.base_domain
-  instance_size = "Extra-large"
-  node_state    = var.bootstrap_state
-  ssh_key_pair  = local.ssh_key_name
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
+  role           = "bootstrap"
+  node_count     = var.bootstrap_count
+  region         = var.region
+  template_id    = data.exoscale_compute_template.rhcos.id
+  base_domain    = var.base_domain
+  instance_size  = "Extra-large"
+  node_state     = var.bootstrap_state
+  ssh_key_pair   = local.ssh_key_name
 
   use_privnet              = var.use_privnet
   privnet_id               = var.use_privnet ? exoscale_network.clusternet.id : ""

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -1,15 +1,16 @@
 module "master" {
   source = "./modules/node-group/"
 
-  cluster_id    = var.cluster_id
-  role          = "master"
-  node_count    = var.master_count
-  region        = var.region
-  template_id   = data.exoscale_compute_template.rhcos.id
-  base_domain   = var.base_domain
-  instance_size = "Extra-large"
-  node_state    = var.master_state
-  ssh_key_pair  = local.ssh_key_name
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
+  role           = "master"
+  node_count     = var.master_count
+  region         = var.region
+  template_id    = data.exoscale_compute_template.rhcos.id
+  base_domain    = var.base_domain
+  instance_size  = "Extra-large"
+  node_state     = var.master_state
+  ssh_key_pair   = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
 

--- a/infra.tf
+++ b/infra.tf
@@ -1,15 +1,16 @@
 module "infra" {
   source = "./modules/node-group"
 
-  cluster_id    = var.cluster_id
-  role          = "infra"
-  node_count    = var.infra_count
-  region        = var.region
-  template_id   = data.exoscale_compute_template.rhcos.id
-  base_domain   = var.base_domain
-  instance_size = var.infra_size
-  node_state    = var.infra_state
-  ssh_key_pair  = local.ssh_key_name
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
+  role           = "infra"
+  node_count     = var.infra_count
+  region         = var.region
+  template_id    = data.exoscale_compute_template.rhcos.id
+  base_domain    = var.base_domain
+  instance_size  = var.infra_size
+  node_state     = var.infra_state
+  ssh_key_pair   = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
   data_disk_size = var.infra_data_disk_size

--- a/lb.tf
+++ b/lb.tf
@@ -29,7 +29,7 @@ resource "random_id" "lb" {
 }
 
 locals {
-  instance_fqdns = formatlist("%s.${var.cluster_id}.${var.base_domain}", random_id.lb[*].hex)
+  instance_fqdns = formatlist("%s.${local.cluster_domain}", random_id.lb[*].hex)
 
   common_user_data = {
     "package_update"  = true,

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
 locals {
-  master_count   = 3
-  privnet_api    = cidrhost(var.privnet_cidr, 100)
-  privnet_gw     = cidrhost(var.privnet_cidr, 1)
-  cluster_domain = "${var.cluster_id}.${var.base_domain}"
-  ssh_key_name   = var.existing_keypair != "" ? var.existing_keypair : exoscale_ssh_keypair.admin[0].name
+  master_count = 3
+  privnet_api  = cidrhost(var.privnet_cidr, 100)
+  privnet_gw   = cidrhost(var.privnet_cidr, 1)
+  ssh_key_name = var.existing_keypair != "" ? var.existing_keypair : exoscale_ssh_keypair.admin[0].name
+
+  cluster_name   = var.cluster_name != "" ? var.cluster_name : var.cluster_id
+  cluster_domain = "${local.cluster_name}.${var.base_domain}"
 }
 
 resource "exoscale_domain" "cluster" {

--- a/main.tf
+++ b/main.tf
@@ -43,5 +43,5 @@ resource "exoscale_domain_record" "api_int" {
   name        = "api-int"
   ttl         = 60
   record_type = var.use_privnet ? "A" : "CNAME"
-  content     = var.use_privnet ? local.privnet_api : "api.${var.cluster_id}.${var.base_domain}"
+  content     = var.use_privnet ? local.privnet_api : "api.${local.cluster_domain}"
 }

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -143,7 +143,7 @@ resource "exoscale_affinity" "anti_affinity_group" {
 
 resource "exoscale_compute" "nodes" {
   count        = var.node_count
-  display_name = "${random_id.node_id[count.index].hex}.${var.cluster_id}.${var.base_domain}"
+  display_name = "${random_id.node_id[count.index].hex}.${var.cluster_domain}"
   hostname     = random_id.node_id[count.index].hex
   key_pair     = var.ssh_key_pair
   zone         = var.region

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -10,6 +10,10 @@ variable "cluster_id" {
   type = string
 }
 
+variable "cluster_domain" {
+  type = string
+}
+
 variable "ssh_key_pair" {
   type    = string
   default = ""

--- a/output.tf
+++ b/output.tf
@@ -5,13 +5,13 @@ output "ns_records" {
 ;
 ; If ${var.base_domain} is a subdomain of one of your zones, you'll need to
 ; adjust the labels of records below to the form
-; '${var.cluster_id}.<subdomain>'.
+; '${local.cluster_name}.<subdomain>'.
 ;
 ; Delegate  ${var.cluster_id}'s subdomain to Exoscale
-${var.cluster_id}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[0].content}.
-${var.cluster_id}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[1].content}.
-${var.cluster_id}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[2].content}.
-${var.cluster_id}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[3].content}.
+${local.cluster_name}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[0].content}.
+${local.cluster_name}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[1].content}.
+${local.cluster_name}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[2].content}.
+${local.cluster_name}  IN  NS     ${data.exoscale_domain_record.exo_nameservers.records[3].content}.
 
 EOF
 }

--- a/storage.tf
+++ b/storage.tf
@@ -1,15 +1,16 @@
 module "storage" {
   source = "./modules/node-group"
 
-  cluster_id    = var.cluster_id
-  role          = "storage"
-  node_count    = var.storage_count
-  region        = var.region
-  template_id   = data.exoscale_compute_template.rhcos.id
-  base_domain   = var.base_domain
-  instance_size = var.storage_size
-  node_state    = var.storage_state
-  ssh_key_pair  = local.ssh_key_name
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
+  role           = "storage"
+  node_count     = var.storage_count
+  region         = var.region
+  template_id    = data.exoscale_compute_template.rhcos.id
+  base_domain    = var.base_domain
+  instance_size  = var.storage_size
+  node_state     = var.storage_state
+  ssh_key_pair   = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,12 @@
 variable "cluster_id" {
-  type = string
+  type        = string
+  description = "The cluster's Project Syn ID"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The cluster's display name. If this is not set, cluster_id is used"
+  default     = ""
 }
 
 variable "region" {

--- a/worker.tf
+++ b/worker.tf
@@ -3,15 +3,16 @@
 module "worker" {
   source = "./modules/node-group"
 
-  cluster_id    = var.cluster_id
-  role          = "worker"
-  node_count    = var.worker_count
-  region        = var.region
-  template_id   = data.exoscale_compute_template.rhcos.id
-  base_domain   = var.base_domain
-  instance_size = var.worker_size
-  node_state    = var.worker_state
-  ssh_key_pair  = local.ssh_key_name
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
+  role           = "worker"
+  node_count     = var.worker_count
+  region         = var.region
+  template_id    = data.exoscale_compute_template.rhcos.id
+  base_domain    = var.base_domain
+  instance_size  = var.worker_size
+  node_state     = var.worker_state
+  ssh_key_pair   = local.ssh_key_name
 
   root_disk_size = var.root_disk_size
   data_disk_size = var.worker_data_disk_size
@@ -39,7 +40,8 @@ module "additional_worker" {
 
   source = "./modules/node-group"
 
-  cluster_id = var.cluster_id
+  cluster_id     = var.cluster_id
+  cluster_domain = local.cluster_domain
 
   role          = each.key
   node_count    = each.value.count


### PR DESCRIPTION
The new variable allows setups where the cluster domain shouldn't contain the cluster id. This is required for the documented DNS scheme for APPUiO Cloud (cf. [APPUiO Cloud DNS scheme](https://kb.vshn.ch/appuio-cloud/references/dns-naming-scheme.html) vs [APPUiO Managed OCP4 DNS scheme](https://kb.vshn.ch/oc4/explanations/dns_scheme.html)).

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
