### PR TITLE
Add security group rules required for Cilium

### DIFF
--- a/security_groups.tf
+++ b/security_groups.tf
@@ -37,6 +37,44 @@ resource "exoscale_security_group_rules" "all_machines" {
     ports                    = ["4789", "6081"]
     user_security_group_list = [exoscale_security_group.all_machines.name]
   }
+
+  ingress {
+    description              = "Cilium VXLAN"
+    protocol                 = "UDP"
+    ports                    = ["8472"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+  ingress {
+    description              = "Cilium health checks"
+    protocol                 = "TCP"
+    ports                    = ["4240"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+  ingress {
+    description              = "Cilium Hubble Server"
+    protocol                 = "TCP"
+    ports                    = ["4244"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+  ingress {
+    description              = "Cilium Hubble Relay"
+    protocol                 = "TCP"
+    ports                    = ["4245"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+  ingress {
+    description              = "Cilium Operator Prometheus metrics"
+    protocol                 = "TCP"
+    ports                    = ["6942"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+  ingress {
+    description              = "Cilium Hubble Enterprise metrics"
+    protocol                 = "TCP"
+    ports                    = ["2112"]
+    user_security_group_list = [exoscale_security_group.all_machines.name]
+  }
+
   ingress {
     description              = "Host level services, including the node exporter on ports 9100-9101"
     protocol                 = "UDP"


### PR DESCRIPTION
Open Cilium VXLAN (8472/udp), health check (4240/tcp), Hubble (4244/tcp,4245/tcp) and metrics (6942/tcp,2112/tcp) ports for traffic between all machines.

Fixes #45

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
