### PR TITLE
Remove all uses of deprecated Exoscale Terraform resources

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -12,7 +12,7 @@ module "bootstrap" {
   region         = var.region
   template_id    = data.exoscale_compute_template.rhcos.id
   base_domain    = var.base_domain
-  instance_size  = "Extra-large"
+  instance_type  = "standard.extra-large"
   node_state     = var.bootstrap_state
   ssh_key_pair   = local.ssh_key_name
 

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -8,7 +8,7 @@ module "master" {
   region         = var.region
   template_id    = data.exoscale_compute_template.rhcos.id
   base_domain    = var.base_domain
-  instance_size  = "Extra-large"
+  instance_type  = "standard.extra-large"
   node_state     = var.master_state
   ssh_key_pair   = local.ssh_key_name
 
@@ -32,7 +32,7 @@ module "master" {
 }
 
 resource "exoscale_domain_record" "etcd" {
-  count       = var.master_state == "Running" ? var.master_count : 0
+  count       = lower(var.master_state) == "running" ? var.master_count : 0
   domain      = exoscale_domain.cluster.id
   name        = "etcd-${count.index}"
   ttl         = 60

--- a/infra.tf
+++ b/infra.tf
@@ -8,7 +8,7 @@ module "infra" {
   region         = var.region
   template_id    = data.exoscale_compute_template.rhcos.id
   base_domain    = var.base_domain
-  instance_size  = var.infra_size
+  instance_type  = var.infra_type
   node_state     = var.infra_state
   ssh_key_pair   = local.ssh_key_name
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   privnet_id = var.use_privnet ? exoscale_network.clusternet[0].id : ""
   privnet_gw = cidrhost(var.privnet_cidr, 1)
 
-  ssh_key_name = var.existing_keypair != "" ? var.existing_keypair : exoscale_ssh_keypair.admin[0].name
+  ssh_key_name = var.existing_keypair != "" ? var.existing_keypair : exoscale_ssh_key.admin[0].name
 
   cluster_name   = var.cluster_name != "" ? var.cluster_name : var.cluster_id
   cluster_domain = "${local.cluster_name}.${var.base_domain}"
@@ -27,7 +27,7 @@ data "exoscale_compute_template" "rhcos" {
   filter = "mine"
 }
 
-resource "exoscale_ssh_keypair" "admin" {
+resource "exoscale_ssh_key" "admin" {
   count      = var.existing_keypair != "" ? 0 : 1
   name       = "${var.cluster_id}-admin"
   public_key = var.ssh_key

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   master_count = 3
 
-  privnet_id = var.use_privnet ? exoscale_network.clusternet[0].id : ""
+  privnet_id = var.use_privnet ? exoscale_private_network.clusternet[0].id : ""
   privnet_gw = cidrhost(var.privnet_cidr, 1)
 
   ssh_key_name = var.existing_keypair != "" ? var.existing_keypair : exoscale_ssh_key.admin[0].name
@@ -33,14 +33,14 @@ resource "exoscale_ssh_key" "admin" {
   public_key = var.ssh_key
 }
 
-resource "exoscale_network" "clusternet" {
-  count        = var.use_privnet ? 1 : 0
-  zone         = var.region
-  name         = "${var.cluster_id}_clusternet"
-  display_text = "${var.cluster_id} private network"
-  start_ip     = cidrhost(var.privnet_cidr, 101)
-  end_ip       = cidrhost(var.privnet_cidr, 253)
-  netmask      = cidrnetmask(var.privnet_cidr)
+resource "exoscale_private_network" "clusternet" {
+  count       = var.use_privnet ? 1 : 0
+  zone        = var.region
+  name        = "${var.cluster_id}_clusternet"
+  description = "${var.cluster_id} private network"
+  start_ip    = cidrhost(var.privnet_cidr, 101)
+  end_ip      = cidrhost(var.privnet_cidr, 253)
+  netmask     = cidrnetmask(var.privnet_cidr)
 }
 
 resource "exoscale_domain_record" "api_int" {

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -45,7 +45,6 @@ locals {
           // fact that we can't set a separate `name` and `display_name` for
           // compute instances anymore.
           [{
-            "filesystem" : "root",
             "path" : "/etc/hostname",
             "mode" : 420,
             "overwrite" : true,
@@ -76,7 +75,6 @@ locals {
   privnet_iface = "ens4"
   privnet_config_files = [
     {
-      "filesystem" : "root",
       "path" : "/etc/sysconfig/network-scripts/ifcfg-ens3",
       "mode" : 420,
       "contents" : {
@@ -84,7 +82,6 @@ locals {
       }
     },
     {
-      "filesystem" : "root",
       "path" : "/etc/sysconfig/network-scripts/ifcfg-${local.privnet_iface}",
       "mode" : 420,
       "contents" : {
@@ -99,7 +96,6 @@ locals {
       }
     },
     {
-      "filesystem" : "root",
       "path" : "/etc/sysconfig/network-scripts/route-${local.privnet_iface}",
       "mode" : 420,
       "contents" : {

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -9,37 +9,63 @@ locals {
 
   is_storage_cluster = var.storage_disk_size > 0
 
-  user_data = base64encode(jsonencode({
-    "ignition" : {
-      "version" : "3.1.0",
-      "config" : {
-        "merge" : [
-          {
-            "source" : lookup(local.ignition_source, var.role, local.ignition_source["worker"])
+  // Generate instance-specific user-data based on `random_id.node_id` This
+  // allows us to construct the complete ignition config here, instead of
+  // having to work around merge() being a shallow merge in the compute
+  // instance resource.
+  user_data = [
+    for hostname in random_id.node_id[*].hex :
+    {
+      "ignition" : {
+        "version" : "3.1.0",
+        "config" : {
+          "merge" : [
+            {
+              "source" : lookup(local.ignition_source, var.role, local.ignition_source["worker"])
+            }
+          ]
+        },
+        "security" : {
+          "tls" : {
+            "certificateAuthorities" : [{
+              "source" : "data:text/plain;charset=utf-8;base64,${base64encode(var.ignition_ca)}"
+            }]
           }
-        ]
-      },
-      "security" : {
-        "tls" : {
-          "certificateAuthorities" : [{
-            "source" : "data:text/plain;charset=utf-8;base64,${base64encode(var.ignition_ca)}"
-          }]
         }
-      }
-    },
-    "storage" : merge(
-      var.use_privnet ? local.privnet_config : {},
-      // We create a custom partition layout if data_disk_size or
-      // storage_disk_size are > 0. This is primarily to avoid issues with sector
-      // rounding during partitioning if the user didn't request extra disk space.
-      var.data_disk_size + var.storage_disk_size > 0 ? local.disks_config : {},
-    ),
-    // For storage cluster nodes we zero the extra partition on first boot to
-    // ensure deploying the storage cluster succeeds.
-    // We don't do this for other nodes where users request extra disk space via
-    // data_disk_size.
-    "systemd" : local.is_storage_cluster ? local.storage_cluster_firstboot_unit : {},
-  }))
+      },
+      // NOTE: merge doesn't deep-merge args, but instead overwrites existing
+      // top-level keys with the contents of the latest argument which has a
+      // top-level key.
+      "storage" : {
+        // concatenate the private network config (if requested) with the
+        // `/etc/hostname` override.
+        "files" : concat(
+          var.use_privnet ? local.privnet_config_files : [],
+          // override /etc/hostname with short hostname, this works around the
+          // fact that we can't set a separate `name` and `display_name` for
+          // compute instances anymore.
+          [{
+            "filesystem" : "root",
+            "path" : "/etc/hostname",
+            "mode" : 420,
+            "overwrite" : true,
+            "contents" : {
+              "source" : "data:,${hostname}"
+            }
+          }]
+        ),
+        // We create a custom partition layout if data_disk_size or
+        // storage_disk_size are > 0. This is primarily to avoid issues with sector
+        // rounding during partitioning if the user didn't request extra disk space.
+        "disks" : var.data_disk_size + var.storage_disk_size > 0 ? local.disks_config : [],
+      },
+      // For storage cluster nodes we zero the extra partition on first boot to
+      // ensure deploying the storage cluster succeeds.
+      // We don't do this for other nodes where users request extra disk space via
+      // data_disk_size.
+      "systemd" : local.is_storage_cluster ? local.storage_cluster_firstboot_unit : {},
+    }
+  ]
 
   # TODO: can we do something smarter than this?
   dns_servers = <<-EOF
@@ -48,65 +74,61 @@ locals {
   EOF
 
   privnet_iface = "ens4"
-  privnet_config = {
-    "files" : [
-      {
-        "filesystem" : "root",
-        "path" : "/etc/sysconfig/network-scripts/ifcfg-ens3",
-        "mode" : 420,
-        "contents" : {
-          "source" : "data:text/plain;charset=utf-8;base64,${base64encode(templatefile("${path.module}/templates/ifcfg.tmpl", { device = "ens3", enabled = "no", custom_dns = "" }))}"
-        }
-      },
-      {
-        "filesystem" : "root",
-        "path" : "/etc/sysconfig/network-scripts/ifcfg-${local.privnet_iface}",
-        "mode" : 420,
-        "contents" : {
-          "source" : "data:text/plain;charset=utf-8;base64,${base64encode(templatefile(
-            "${path.module}/templates/ifcfg.tmpl",
-            {
-              device     = local.privnet_iface
-              enabled    = "yes"
-              custom_dns = local.dns_servers
-            }
-          ))}"
-        }
-      },
-      {
-        "filesystem" : "root",
-        "path" : "/etc/sysconfig/network-scripts/route-${local.privnet_iface}",
-        "mode" : 420,
-        "contents" : {
-          "source" : "data:text/plain;charset=utf-8;base64,${base64encode("default via ${var.privnet_gw}")}"
-        }
+  privnet_config_files = [
+    {
+      "filesystem" : "root",
+      "path" : "/etc/sysconfig/network-scripts/ifcfg-ens3",
+      "mode" : 420,
+      "contents" : {
+        "source" : "data:text/plain;charset=utf-8;base64,${base64encode(templatefile("${path.module}/templates/ifcfg.tmpl", { device = "ens3", enabled = "no", custom_dns = "" }))}"
       }
-    ]
-  }
-
-  disks_config = {
-    "disks" : [
-      {
-        "device" : "/dev/vda",
-        "partitions" : [
+    },
+    {
+      "filesystem" : "root",
+      "path" : "/etc/sysconfig/network-scripts/ifcfg-${local.privnet_iface}",
+      "mode" : 420,
+      "contents" : {
+        "source" : "data:text/plain;charset=utf-8;base64,${base64encode(templatefile(
+          "${path.module}/templates/ifcfg.tmpl",
           {
-            "label" : "root",
-            "number" : 4,
-            "shouldExist" : true,
-            "sizeMiB" : var.root_disk_size * 1024,
-            "wipePartitionEntry" : true
-          },
-          {
-            "label" : "data",
-            "number" : 0,
-            "shouldExist" : true,
-            "sizeMiB" : 0,
-            "startMiB" : 0
+            device     = local.privnet_iface
+            enabled    = "yes"
+            custom_dns = local.dns_servers
           }
-        ]
+        ))}"
       }
-    ]
-  }
+    },
+    {
+      "filesystem" : "root",
+      "path" : "/etc/sysconfig/network-scripts/route-${local.privnet_iface}",
+      "mode" : 420,
+      "contents" : {
+        "source" : "data:text/plain;charset=utf-8;base64,${base64encode("default via ${var.privnet_gw}")}"
+      }
+    }
+  ]
+
+  disks_config = [
+    {
+      "device" : "/dev/vda",
+      "partitions" : [
+        {
+          "label" : "root",
+          "number" : 4,
+          "shouldExist" : true,
+          "sizeMiB" : var.root_disk_size * 1024,
+          "wipePartitionEntry" : true
+        },
+        {
+          "label" : "data",
+          "number" : 0,
+          "shouldExist" : true,
+          "sizeMiB" : 0,
+          "startMiB" : 0
+        }
+      ]
+    }
+  ]
 
   storage_cluster_firstboot_unit = {
     "units" : [
@@ -156,7 +178,7 @@ resource "exoscale_compute_instance" "nodes" {
   template_id = var.template_id
   type        = var.instance_type
   disk_size   = local.disk_size
-  user_data   = local.user_data
+  user_data   = base64encode(jsonencode(local.user_data[count.index]))
 
   # Always lowercase the provided state
   state = lower(var.node_state)

--- a/modules/node-group/output.tf
+++ b/modules/node-group/output.tf
@@ -1,3 +1,3 @@
 output "ip_address" {
-  value = var.use_privnet ? exoscale_nic.nodes[*].ip_address : exoscale_compute.nodes[*].ip_address
+  value = var.use_privnet ? exoscale_compute_instance.nodes[*].network_interface[0].ip_address : exoscale_compute_instance.nodes[*].public_ip_address
 }

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -23,9 +23,9 @@ variable "region" {
   type = string
 }
 
-variable "instance_size" {
+variable "instance_type" {
   type    = string
-  default = "Extra-large"
+  default = "standard.extra-large"
 }
 
 variable "root_disk_size" {
@@ -95,7 +95,7 @@ variable "privnet_dhcp_reservation" {
 
 variable "node_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "storage_disk_size" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -134,14 +134,21 @@ resource "exoscale_security_group" "infra" {
   name        = "${var.cluster_id}_infra"
   description = "${var.cluster_id} infra nodes"
 }
-resource "exoscale_security_group_rules" "infra" {
-  security_group = exoscale_security_group.infra.name
-  ingress {
-    description              = "Ingress controller TCP"
-    protocol                 = "TCP"
-    ports                    = ["80", "443"]
-    user_security_group_list = [module.lb.security_group_name]
+resource "exoscale_security_group_rule" "infra" {
+  for_each = {
+    HTTP  = "80"
+    HTTPS = "443"
   }
+
+  security_group_id = exoscale_security_group.infra.id
+
+  type        = "INGRESS"
+  description = "Ingress controller TCP"
+  protocol    = "TCP"
+  start_port  = each.value
+  end_port    = each.value
+
+  user_security_group_id = data.exoscale_security_group.lb.id
 }
 
 resource "exoscale_security_group" "storage" {

--- a/storage.tf
+++ b/storage.tf
@@ -8,7 +8,7 @@ module "storage" {
   region         = var.region
   template_id    = data.exoscale_compute_template.rhcos.id
   base_domain    = var.base_domain
-  instance_size  = var.storage_size
+  instance_type  = var.storage_type
   node_state     = var.storage_state
   ssh_key_pair   = local.ssh_key_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,44 +71,44 @@ variable "lb_count" {
   default = 2
 }
 
-variable "worker_size" {
+variable "worker_type" {
   type    = string
-  default = "Extra-large"
+  default = "standard.extra-large"
 }
 
-variable "infra_size" {
+variable "infra_type" {
   type    = string
-  default = "Extra-large"
+  default = "standard.extra-large"
 }
 
-variable "storage_size" {
+variable "storage_type" {
   type    = string
-  default = "CPU-extra-large"
+  default = "cpu.extra-large"
 }
 
 variable "bootstrap_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "master_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "worker_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "infra_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "storage_state" {
   type    = string
-  default = "Running"
+  default = "running"
 }
 
 variable "root_disk_size" {
@@ -152,7 +152,7 @@ variable "storage_cluster_disk_size" {
 }
 
 variable "additional_worker_groups" {
-  type    = map(object({ size = string, count = number, data_disk_size = optional(number), state = optional(string), affinity_group_ids = optional(list(string)) }))
+  type    = map(object({ type = string, count = number, data_disk_size = optional(number), state = optional(string), affinity_group_ids = optional(list(string)) }))
   default = {}
 
   validation {
@@ -161,12 +161,12 @@ variable "additional_worker_groups" {
       !contains(["worker", "master", "infra", "storage"], k) &&
       v.count >= 0 &&
       (v.data_disk_size != null ? v.data_disk_size >= 0 : true) &&
-      (v.state != null ? v.state == "Running" || v.state == "Stopped" : true)
+      (v.state != null ? lower(v.state) == "running" || lower(v.state) == "stopped" : true)
     ])
     // Cannot use any of the nicer string formatting options because
     // error_message validation is dumb, cf.
     // https://github.com/hashicorp/terraform/issues/24123
-    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The worker data disk size cannot be negative.\n * Additional worker group names cannot be 'worker', 'master', 'infra', or 'storage'.\n * The only valid worker states are 'Running' or 'Stopped'.\n * The worker count cannot be less than 0."
+    error_message = "Your configuration of `additional_worker_groups` violates one of the following constraints:\n * The worker data disk size cannot be negative.\n * Additional worker group names cannot be 'worker', 'master', 'infra', or 'storage'.\n * The only valid worker states are 'running' or 'stopped'.\n * The worker count cannot be less than 0."
   }
 }
 

--- a/worker.tf
+++ b/worker.tf
@@ -10,7 +10,7 @@ module "worker" {
   region         = var.region
   template_id    = data.exoscale_compute_template.rhcos.id
   base_domain    = var.base_domain
-  instance_size  = var.worker_size
+  instance_type  = var.worker_type
   node_state     = var.worker_state
   ssh_key_pair   = local.ssh_key_name
 
@@ -46,9 +46,9 @@ module "additional_worker" {
 
   role          = each.key
   node_count    = each.value.count
-  instance_size = each.value.size
-  // Default node_state to "Running" if not specified in map entry
-  node_state = each.value.state != null ? each.value.state : "Running"
+  instance_type = each.value.type
+  // Default node_state to "running" if not specified in map entry
+  node_state = each.value.state != null ? each.value.state : "running"
 
   root_disk_size = var.root_disk_size
   // Default data disk size to 0 if map entry doesn't have field disk_size


### PR DESCRIPTION
Closes #59  

This PR requires that the Terraform state of existing clusters is updated manually, please see https://github.com/appuio/component-openshift4-terraform/pull/61 for a Python script which performs the required state migrations.

I've tested both provisioning resources using the new module version and the state migration for resources initially setup with an old module version.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
