### PR TITLE
Remove unused DNS records

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -31,12 +31,3 @@ module "bootstrap" {
 
   bootstrap_bucket = var.bootstrap_bucket
 }
-
-resource "exoscale_domain_record" "bootstrap_api_member" {
-  count       = var.bootstrap_state == "Running" ? var.bootstrap_count : 0
-  domain      = exoscale_domain.cluster.id
-  name        = "api-member"
-  ttl         = 60
-  record_type = "A"
-  content     = module.bootstrap.ip_address[0]
-}

--- a/infra.tf
+++ b/infra.tf
@@ -31,12 +31,3 @@ module "infra" {
 
   bootstrap_bucket = var.bootstrap_bucket
 }
-
-resource "exoscale_domain_record" "router_member" {
-  count       = var.infra_state == "Running" ? var.infra_count : 0
-  domain      = exoscale_domain.cluster.id
-  name        = "router-member"
-  ttl         = 60
-  record_type = "A"
-  content     = module.infra.ip_address[count.index]
-}


### PR DESCRIPTION
Since we've switched to the VSHN Puppet-managed LBs, we don't need the `api-member` and `router-member` DNS records anymore. 

Factored out from #60 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
