### PR TITLE
Fix validation logic for `additional_node_groups.*.state`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "additional_worker_groups" {
       !contains(["worker", "master", "infra", "storage"], k) &&
       v.count >= 0 &&
       (v.data_disk_size != null ? v.data_disk_size >= 0 : true) &&
-      (v.state == null || v.state == "Running" || v.state == "Stopped")
+      (v.state != null ? v.state == "Running" || v.state == "Stopped" : true)
     ])
     // Cannot use any of the nicer string formatting options because
     // error_message validation is dumb, cf.


### PR DESCRIPTION
I've encountered errors like reproduced below while testing the state migration for #60.

```
│   on .terraform/modules/cluster/variables.tf line 164, in variable "additional_worker_groups":
│  164:       (v.state == null || lower(v.state) == "running" || lower(v.state) == "stopped")
│     ├────────────────
│     │ v.state is null
│
│ Invalid value for "str" parameter: argument must not be null.
```

Since Terraform boolean operators don't short-circuit, we should use the ternary operator form to perform the validation anyway (we already do this for the disk size parameter). Currently the old approach works because apparently you can compare a string to `null`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
