### PR TITLE
Update `vshn-lbaas-exoscale` module to v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The module provides variables to
 * configure additional Exoscale private networks to attach to the LBs.
   To avoid issues with network interfaces getting assigned arbitrarily, we recommend to only configure additional private networks after the LBs have been provisioned.
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
-* specify an Exoscale API key and secret for Floaty
 * specify the username for the APPUiO hieradata Git repository (see next sections for details).
 * provide an API token for control.vshn.net (see next sections for details).
 
@@ -98,8 +97,6 @@ module "cluster" {
 ## Required credentials
 
 * An unrestricted Exoscale API key in the organisation in which the cluster should be deployed
-* An Exoscale API key for Floaty
-  * The minimum required permissions for the Floaty API key are the following Compute operations: `addIpToNic`, `listNics`, `listResourceDetails`, `listVirtualMachines`, `queryAsyncJobResult` and `removeIpFromNic`.
 * An API token for the Servers API must be created on [control.vshn.net](https://control.vshn.net/tokens/_create/servers)
 * A project access token for the APPUiO hieradata repository must be created on [git.vshn.net](https://git.vshn.net/appuio/appuio_hieradata/-/settings/access_tokens)
   * The minimum required permissions for the project access token are `api` (to create MRs), `read_repository` (to clone the repo) and `write_repository` (to push to the repo).

--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v3.0.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.0.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {
@@ -14,14 +14,12 @@ module "lb" {
   control_vshn_net_token = var.control_vshn_net_token
   team                   = var.team
 
-  api_backends           = exoscale_domain_record.etcd[*].hostname
-  router_backends        = module.infra.ip_address[*]
-  bootstrap_node         = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
-  lb_exoscale_api_key    = var.lb_exoscale_api_key
-  lb_exoscale_api_secret = var.lb_exoscale_api_secret
-  hieradata_repo_user    = var.hieradata_repo_user
-  enable_proxy_protocol  = var.lb_enable_proxy_protocol
-  additional_networks    = var.additional_lb_networks
+  api_backends          = exoscale_domain_record.etcd[*].hostname
+  router_backends       = module.infra.ip_address[*]
+  bootstrap_node        = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
+  hieradata_repo_user   = var.hieradata_repo_user
+  enable_proxy_protocol = var.lb_enable_proxy_protocol
+  additional_networks   = var.additional_lb_networks
 
   cluster_security_group_names = [
     exoscale_security_group.all_machines.name

--- a/variables.tf
+++ b/variables.tf
@@ -186,13 +186,6 @@ variable "ignition_ca" {
   type = string
 }
 
-variable "lb_exoscale_api_key" {
-  type = string
-}
-variable "lb_exoscale_api_secret" {
-  type = string
-}
-
 variable "bootstrap_bucket" {
   type = string
 }


### PR DESCRIPTION
The new module version manages the Floaty Exoscale access key through Terraform, so this commit also removes the variables to pass through an externally created Floaty access key.

This is a breaking change because it removes module input variables.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
