### PR TITLE
Add support for configuring deployment target ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The module provides variables to
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
 * specify the username for the APPUiO hieradata Git repository (see next sections for details).
 * provide an API token for control.vshn.net (see next sections for details).
+* choose a dedicated deployment target
+  This allows for using dedicated hypervisors.
 
 The cluster's domain is constructed from the provided base domain, cluster id and cluster name.
 If a cluster name is provided the cluster domain is set to `<cluster name>.<base domain>`.

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -28,6 +28,8 @@ module "master" {
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 
+  deploy_target_id = var.deploy_target_id
+
   bootstrap_bucket = var.bootstrap_bucket
 }
 

--- a/infra.tf
+++ b/infra.tf
@@ -29,5 +29,7 @@ module "infra" {
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 
+  deploy_target_id = var.deploy_target_id
+
   bootstrap_bucket = var.bootstrap_bucket
 }

--- a/lb.tf
+++ b/lb.tf
@@ -27,6 +27,8 @@ module "lb" {
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 
+  deploy_target_id = var.deploy_target_id
+
   depends_on = [
     exoscale_domain.cluster,
     exoscale_security_group.all_machines,

--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.0.1"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.1.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -185,6 +185,8 @@ resource "exoscale_compute_instance" "nodes" {
     var.additional_affinity_group_ids
   )
 
+  deploy_target_id = var.deploy_target_id
+
   dynamic "network_interface" {
     for_each = local.privnet_interface
 

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -118,5 +118,5 @@ variable "additional_affinity_group_ids" {
 variable "deploy_target_id" {
   type        = string
   default     = ""
-  description = "ID of special deployment target, eg. dedicated hypervisors"
+  description = "ID of special deployment target, e.g. dedicated hypervisors"
 }

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -114,3 +114,9 @@ variable "additional_affinity_group_ids" {
   default     = []
   description = "List of additional affinity group IDs to configure on all nodes"
 }
+
+variable "deploy_target_id" {
+  type        = string
+  default     = ""
+  description = "ID of special deployment target, eg. dedicated hypervisors"
+}

--- a/storage.tf
+++ b/storage.tf
@@ -33,5 +33,7 @@ module "storage" {
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 
+  deploy_target_id = var.deploy_target_id
+
   bootstrap_bucket = var.bootstrap_bucket
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,12 @@ variable "additional_security_group_ids" {
   description = "List of additional security group IDs to configure on worker nodes"
 }
 
+variable "deploy_target_id" {
+  type        = string
+  default     = ""
+  description = "ID of special deployment target, eg. dedicated hypervisors"
+}
+
 variable "ignition_ca" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -185,7 +185,7 @@ variable "additional_security_group_ids" {
 variable "deploy_target_id" {
   type        = string
   default     = ""
-  description = "ID of special deployment target, eg. dedicated hypervisors"
+  description = "ID of special deployment target, e.g. dedicated hypervisors"
 }
 
 variable "ignition_ca" {

--- a/worker.tf
+++ b/worker.tf
@@ -31,6 +31,8 @@ module "worker" {
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 
+  deploy_target_id = var.deploy_target_id
+
   bootstrap_bucket = var.bootstrap_bucket
 }
 
@@ -75,6 +77,8 @@ module "additional_worker" {
     each.value.affinity_group_ids != null ? each.value.affinity_group_ids : [],
     var.additional_affinity_group_ids
   )
+
+  deploy_target_id = var.deploy_target_id
 
   bootstrap_bucket = var.bootstrap_bucket
 }


### PR DESCRIPTION
Follow-up to #59. When upgrading the Exoscale Terraform provider, we assumed that we can still pass arbitrary affinity group IDs to instances through `anti_affinity_group_ids`, but that parameter has been changed to only accept anti-affinity groups, while there's a new parameter `deploy_target_id` for other affinity group IDs, such as the one necessary to schedule instances on dedicated hypervisors.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
