### PR TITLE
Switch LB module security group inputs and outputs to IDs

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.1.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.2.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {
@@ -21,8 +21,8 @@ module "lb" {
   enable_proxy_protocol = var.lb_enable_proxy_protocol
   additional_networks   = var.additional_lb_networks
 
-  cluster_security_group_names = [
-    exoscale_security_group.all_machines.name
+  cluster_security_group_ids = [
+    exoscale_security_group.all_machines.id
   ]
 
   additional_affinity_group_ids = var.additional_affinity_group_ids

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,7 +1,3 @@
-data "exoscale_security_group" "lb" {
-  name       = module.lb.security_group_name
-  depends_on = [module.lb]
-}
 # https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal/installing-bare-metal.html#installation-network-user-infra_installing-bare-metal
 resource "exoscale_security_group" "all_machines" {
   name        = "${var.cluster_id}_all_machines"
@@ -117,7 +113,7 @@ resource "exoscale_security_group_rule" "control_plane_machine_config_server" {
   start_port  = "22623"
   end_port    = "22623"
 
-  user_security_group_id = data.exoscale_security_group.lb.id
+  user_security_group_id = module.lb.security_group_id
 }
 resource "exoscale_security_group_rule" "control_plane_kubernetes_api" {
   security_group_id = exoscale_security_group.control_plane.id
@@ -149,7 +145,7 @@ resource "exoscale_security_group_rule" "infra" {
   start_port  = each.value
   end_port    = each.value
 
-  user_security_group_id = data.exoscale_security_group.lb.id
+  user_security_group_id = module.lb.security_group_id
 }
 
 resource "exoscale_security_group" "storage" {


### PR DESCRIPTION
By using security group names across the module boundary, we triggered a bug in the Terraform Exoscale provider which results in inconsistent final plans during the initial `terraform apply`.

This commit updates the LB module to v4.2.0 (which includes https://github.com/appuio/terraform-modules/pull/39) and updates the surrounding Terraform to use security group IDs directly.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
