### PR TITLE
Ignore Elastic IPs attached to compute instances

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -199,7 +199,8 @@ resource "exoscale_compute_instance" "nodes" {
   lifecycle {
     ignore_changes = [
       template_id,
-      user_data
+      user_data,
+      elastic_ip_ids
     ]
   }
 }


### PR DESCRIPTION
We don't manage EIP attachments on cluster instances with Terraform. Ignore changes to the `elastic_ip_ids` field during `terraform plan` / `terraform apply` to not remove attachments managed outside Terraform.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
