### PR TITLE
Switch back to user-provided IAM key for Floaty

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The module provides variables to
 * configure additional Exoscale private networks to attach to the LBs.
   To avoid issues with network interfaces getting assigned arbitrarily, we recommend to only configure additional private networks after the LBs have been provisioned.
 * specify a bootstrap S3 bucket (required only to provision the boostrap node)
+* specify an Exoscale API key and secret for Floaty
 * specify the username for the APPUiO hieradata Git repository (see next sections for details).
 * provide an API token for control.vshn.net (see next sections for details).
 * choose a dedicated deployment target
@@ -99,6 +100,8 @@ module "cluster" {
 ## Required credentials
 
 * An unrestricted Exoscale API key in the organisation in which the cluster should be deployed
+* An Exoscale API key for Floaty
+  * The minimum required permissions for the Floaty API key are the following "compute-legacy" operations: `addIpToNic`, `listNics`, `listResourceDetails`, `listVirtualMachines`, `queryAsyncJobResult` and `removeIpFromNic`.
 * An API token for the Servers API must be created on [control.vshn.net](https://control.vshn.net/tokens/_create/servers)
 * A project access token for the APPUiO hieradata repository must be created on [git.vshn.net](https://git.vshn.net/appuio/appuio_hieradata/-/settings/access_tokens)
   * The minimum required permissions for the project access token are `api` (to create MRs), `read_repository` (to clone the repo) and `write_repository` (to push to the repo).

--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v4.2.1"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v5.1.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {
@@ -14,12 +14,14 @@ module "lb" {
   control_vshn_net_token = var.control_vshn_net_token
   team                   = var.team
 
-  api_backends          = exoscale_domain_record.etcd[*].hostname
-  router_backends       = module.infra.ip_address[*]
-  bootstrap_node        = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
-  hieradata_repo_user   = var.hieradata_repo_user
-  enable_proxy_protocol = var.lb_enable_proxy_protocol
-  additional_networks   = var.additional_lb_networks
+  api_backends           = exoscale_domain_record.etcd[*].hostname
+  router_backends        = module.infra.ip_address[*]
+  bootstrap_node         = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
+  lb_exoscale_api_key    = var.lb_exoscale_api_key
+  lb_exoscale_api_secret = var.lb_exoscale_api_secret
+  hieradata_repo_user    = var.hieradata_repo_user
+  enable_proxy_protocol  = var.lb_enable_proxy_protocol
+  additional_networks    = var.additional_lb_networks
 
   cluster_security_group_ids = [
     exoscale_security_group.all_machines.id

--- a/modules/node-group/providers.tf
+++ b/modules/node-group/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     exoscale = {
       source  = "exoscale/exoscale"
-      version = "0.41.1"
+      version = "0.50.0"
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     exoscale = {
       source  = "exoscale/exoscale"
-      version = "0.41.1"
+      version = "0.50.0"
     }
     gitfile = {
       source  = "igal-s/gitfile"

--- a/variables.tf
+++ b/variables.tf
@@ -192,6 +192,13 @@ variable "ignition_ca" {
   type = string
 }
 
+variable "lb_exoscale_api_key" {
+  type = string
+}
+variable "lb_exoscale_api_secret" {
+  type = string
+}
+
 variable "bootstrap_bucket" {
   type = string
 }


### PR DESCRIPTION
Exoscale's new IAM API (v3) isn't yet supported by the Terraform module, so we switch back to a user-provided IAM key for Floaty

This reverts #69 (commit c6938673f029a3cacebf57a555e05f10f385a38d), reversing changes made to 10e07d48fe8de339e2a6084b8e419763c1aeda49.

This PR also updates the Exoscale Terraform provider to v0.50.0, since we've updated the provider in the vshn-lbaas-exoscale module as well.

See https://github.com/appuio/terraform-modules/releases/tag/v5.0.0

Replaces #81 #76 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.
- [x] Switch to tagged terraform-modules version

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
