### PR TITLE
Switch to new `exoscale_template` data source

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -10,7 +10,7 @@ module "bootstrap" {
   role           = "bootstrap"
   node_count     = var.bootstrap_count
   region         = var.region
-  template_id    = data.exoscale_compute_template.rhcos.id
+  template_id    = data.exoscale_template.rhcos.id
   base_domain    = var.base_domain
   instance_type  = "standard.extra-large"
   node_state     = var.bootstrap_state

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -6,7 +6,7 @@ module "master" {
   role           = "master"
   node_count     = var.master_count
   region         = var.region
-  template_id    = data.exoscale_compute_template.rhcos.id
+  template_id    = data.exoscale_template.rhcos.id
   base_domain    = var.base_domain
   instance_type  = "standard.extra-large"
   node_state     = var.master_state

--- a/infra.tf
+++ b/infra.tf
@@ -6,7 +6,7 @@ module "infra" {
   role           = "infra"
   node_count     = var.infra_count
   region         = var.region
-  template_id    = data.exoscale_compute_template.rhcos.id
+  template_id    = data.exoscale_template.rhcos.id
   base_domain    = var.base_domain
   instance_type  = var.infra_type
   node_state     = var.infra_state

--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,10 @@ data "exoscale_domain_record" "exo_nameservers" {
   }
 }
 
-data "exoscale_compute_template" "rhcos" {
-  zone   = var.region
-  name   = var.rhcos_template
-  filter = "mine"
+data "exoscale_template" "rhcos" {
+  zone       = var.region
+  name       = var.rhcos_template
+  visibility = "private"
 }
 
 resource "exoscale_ssh_key" "admin" {

--- a/storage.tf
+++ b/storage.tf
@@ -6,7 +6,7 @@ module "storage" {
   role           = "storage"
   node_count     = var.storage_count
   region         = var.region
-  template_id    = data.exoscale_compute_template.rhcos.id
+  template_id    = data.exoscale_template.rhcos.id
   base_domain    = var.base_domain
   instance_type  = var.storage_type
   node_state     = var.storage_state

--- a/worker.tf
+++ b/worker.tf
@@ -8,7 +8,7 @@ module "worker" {
   role           = "worker"
   node_count     = var.worker_count
   region         = var.region
-  template_id    = data.exoscale_compute_template.rhcos.id
+  template_id    = data.exoscale_template.rhcos.id
   base_domain    = var.base_domain
   instance_type  = var.worker_type
   node_state     = var.worker_state
@@ -57,7 +57,7 @@ module "additional_worker" {
   data_disk_size = each.value.data_disk_size != null ? each.value.data_disk_size : 0
 
   region       = var.region
-  template_id  = data.exoscale_compute_template.rhcos.id
+  template_id  = data.exoscale_template.rhcos.id
   base_domain  = var.base_domain
   ssh_key_pair = local.ssh_key_name
 


### PR DESCRIPTION
The exoscale_compute_template data source has been deprecated in favor of the exoscale_template data source.

With this change, the Terraform module doesn't use any "compute-legacy" API endpoints anymore, which makes working with IAM v3 roles a bit easier.

Follow-up to #80 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
