### PR TITLE
Change default root disk size to 100Gi

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -200,7 +200,7 @@ resource "exoscale_compute_instance" "nodes" {
     ignore_changes = [
       template_id,
       user_data,
-      elastic_ip_ids
+      elastic_ip_ids,
     ]
   }
 }

--- a/modules/node-group/variables.tf
+++ b/modules/node-group/variables.tf
@@ -30,11 +30,11 @@ variable "instance_type" {
 
 variable "root_disk_size" {
   type    = number
-  default = 120
+  default = 100
 
   validation {
-    condition     = var.root_disk_size >= 120
-    error_message = "The minimum supported root disk size for OCP4 is 120GB."
+    condition     = var.root_disk_size >= 100
+    error_message = "The minimum supported root disk size for OCP4 is 100GB."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -113,11 +113,11 @@ variable "storage_state" {
 
 variable "root_disk_size" {
   type    = number
-  default = 120
+  default = 100
 
   validation {
-    condition     = var.root_disk_size >= 120
-    error_message = "The minimum supported root disk size is 120GB."
+    condition     = var.root_disk_size >= 100
+    error_message = "The minimum supported root disk size is 100GB."
   }
 }
 


### PR DESCRIPTION
RedHat lowered requirements for OpenShift node root disk size to 100Gi.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
