### PR TITLE
Restrict SSH access to cluster VMs

### DIFF
--- a/security_groups.tf
+++ b/security_groups.tf
@@ -65,26 +65,16 @@ resource "exoscale_security_group_rule" "all_machines_icmp" {
   cidr        = "0.0.0.0/0"
 }
 
-resource "exoscale_security_group_rule" "all_machines_ssh_v4" {
+resource "exoscale_security_group_rule" "all_machines_ssh" {
   security_group_id = exoscale_security_group.all_machines.id
 
-  description = "SSH Access"
+  description = "SSH Access from cluster VMs and LBs"
   type        = "INGRESS"
   protocol    = "TCP"
   start_port  = "22"
   end_port    = "22"
-  cidr        = "0.0.0.0/0"
-}
 
-resource "exoscale_security_group_rule" "all_machines_ssh_v6" {
-  security_group_id = exoscale_security_group.all_machines.id
-
-  description = "SSH Access"
-  type        = "INGRESS"
-  protocol    = "TCP"
-  start_port  = "22"
-  end_port    = "22"
-  cidr        = "::/0"
+  user_security_group_id = exoscale_security_group.all_machines.id
 }
 
 resource "exoscale_security_group" "control_plane" {


### PR DESCRIPTION
We remove the SSH access from anywhere for the cluster VMs by updating the `all_machines` security group to only allow SSH from other machines in the `all_machines` security group.

This PR requires https://github.com/appuio/terraform-modules/pull/51 in order to ensure that the LBs remain accessible from anywhere via SSH and can act as SSH jumphosts for SSH access to the cluster VMs.

Resolves #78 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
