### PR TITLE
Manage Floaty credentials in Terraform via vshn-lbaas-exoscale v6.0.0

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v5.2.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v6.0.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {
@@ -14,14 +14,12 @@ module "lb" {
   control_vshn_net_token = var.control_vshn_net_token
   team                   = var.team
 
-  api_backends           = exoscale_domain_record.etcd[*].hostname
-  router_backends        = module.infra.ip_address[*]
-  bootstrap_node         = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
-  lb_exoscale_api_key    = var.lb_exoscale_api_key
-  lb_exoscale_api_secret = var.lb_exoscale_api_secret
-  hieradata_repo_user    = var.hieradata_repo_user
-  enable_proxy_protocol  = var.lb_enable_proxy_protocol
-  additional_networks    = var.additional_lb_networks
+  api_backends          = exoscale_domain_record.etcd[*].hostname
+  router_backends       = module.infra.ip_address[*]
+  bootstrap_node        = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
+  hieradata_repo_user   = var.hieradata_repo_user
+  enable_proxy_protocol = var.lb_enable_proxy_protocol
+  additional_networks   = var.additional_lb_networks
 
   cluster_security_group_ids = [
     exoscale_security_group.all_machines.id

--- a/variables.tf
+++ b/variables.tf
@@ -192,13 +192,6 @@ variable "ignition_ca" {
   type = string
 }
 
-variable "lb_exoscale_api_key" {
-  type = string
-}
-variable "lb_exoscale_api_secret" {
-  type = string
-}
-
 variable "bootstrap_bucket" {
   type = string
 }


### PR DESCRIPTION
This is a breaking change for clusters that were setup with or upgraded to v3 of the Terraform module because migrating to the new Terraform-managed Floaty credentials will require manual steps to ensure that the migration takes place without outages. We'll provide detailed instructions for the upgrade in the openshift4-terraform Commodore component.

Replaces #90 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
