### PR TITLE
Introduce new optional variable to attach additional security groups to the LBs

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -21,9 +21,10 @@ module "lb" {
   enable_proxy_protocol = var.lb_enable_proxy_protocol
   additional_networks   = var.additional_lb_networks
 
-  cluster_security_group_ids = [
-    exoscale_security_group.all_machines.id
-  ]
+  cluster_security_group_ids = concat(
+    [exoscale_security_group.all_machines.id],
+    var.additional_lb_security_group_ids
+  )
 
   additional_affinity_group_ids = var.additional_affinity_group_ids
 

--- a/variables.tf
+++ b/variables.tf
@@ -232,3 +232,9 @@ variable "additional_lb_networks" {
   description = "List of UUIDs of additional Exoscale private networks to attach"
   default     = []
 }
+
+variable "additional_lb_security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of additional security group IDs to configure on the LBs"
+}


### PR DESCRIPTION
This is necessary to open the additional ports when using the additional TCP port mappings feature of the Puppet-managed LBs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
