### PR TITLE
Only try to create instancepool when `node_count > 0`

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -213,7 +213,7 @@ resource "exoscale_compute_instance" "nodes" {
 }
 
 resource "exoscale_instance_pool" "nodes" {
-  count       = var.use_instancepool ? local.anti_affinity_group_count : 0
+  count       = var.use_instancepool && var.node_count > 0 ? local.anti_affinity_group_count : 0
   name        = "${var.cluster_id}_${var.role}-${count.index}"
   size        = var.node_count
   zone        = var.region


### PR DESCRIPTION
Fixes cluster bootstrap in instancepool mode, follow-up to #98 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
