### PR TITLE
Support provisioning OKE clusters

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -15,7 +15,7 @@ module "lb" {
   team                   = var.team
 
   api_backends          = exoscale_domain_record.etcd[*].hostname
-  router_backends       = module.infra.ip_address[*]
+  router_backends       = var.infra_count > 0 ? module.infra.ip_address[*] : module.worker.ip_address[*]
   bootstrap_node        = var.bootstrap_count > 0 ? module.bootstrap.ip_address[0] : ""
   hieradata_repo_user   = var.hieradata_repo_user
   enable_proxy_protocol = var.lb_enable_proxy_protocol

--- a/worker.tf
+++ b/worker.tf
@@ -27,6 +27,7 @@ module "worker" {
   security_group_ids = concat(
     var.additional_security_group_ids,
     [exoscale_security_group.all_machines.id],
+    var.infra_count == 0 ? [exoscale_security_group.infra.id] : [],
     var.use_instancepools ? [exoscale_security_group.worker.id] : []
   )
 


### PR DESCRIPTION
We provision OKE clusters with `infra_count = 0`. This PR adjusts the Terraform to use the worker node IPs as router backends for the Puppet-managed LBs and to add the infra security group to the worker nodes when `infra_count = 0`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
