### PR TITLE
Switch infra nodes to non-instancepool by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ The module provides variables to
 * choose a dedicated deployment target
   This allows for using dedicated hypervisors.
 * choose to provision Exoscale instance pools for the infra and worker nodes.
-  NOTE: we currently don't support provisioning Exoscale instance pools for the control plane and storage nodes.
+  Note that we currently don't support provisioning Exoscale instance pools for the control plane and storage nodes.
+  By default, we only provision instance pools for the worker nodes.
+  If you wish to use an instance pool for the infra nodes, you need to set variable `infra_use_instancepool = true`.
 
 The cluster's domain is constructed from the provided base domain, cluster id and cluster name.
 If a cluster name is provided the cluster domain is set to `<cluster name>.<base domain>`.

--- a/infra.tf
+++ b/infra.tf
@@ -34,5 +34,5 @@ module "infra" {
 
   bootstrap_bucket = var.bootstrap_bucket
 
-  use_instancepool = var.use_instancepools
+  use_instancepool = var.use_instancepools && var.infra_use_instancepool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -244,3 +244,9 @@ variable "use_instancepools" {
   description = "Use instance pools for node groups"
   default     = true
 }
+
+variable "infra_use_instancepool" {
+  type        = bool
+  description = "Use instance pool for infra nodes. Only has an effect if `use_instancepools=true`"
+  default     = false
+}


### PR DESCRIPTION
We've realized that with the current state of NLBs (which aren't suitable for replacing the Puppet-managed LBs at this point), having an instancepool for the infra nodes brings more issues than it solves.

This commit introduces a new variable `infra_use_instancepool` which defaults to `false` and must be set to `true` in addition to `use_instancepools = true` for the module to provision an instancepool for the infra nodes.

See also #98 

This is a breaking change for existing clusters which use `use_instancepools = true`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
