### PR TITLE
Make LB disk size configurable

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v6.5.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v6.6.0"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {
@@ -13,6 +13,7 @@ module "lb" {
   lb_count               = var.lb_count
   control_vshn_net_token = var.control_vshn_net_token
   team                   = var.team
+  disk_size              = var.lb_disk_size
 
   api_backends          = exoscale_domain_record.etcd[*].hostname
   router_backends       = var.infra_count > 0 ? module.infra.ip_address[*] : module.worker.ip_address[*]

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,12 @@ variable "additional_lb_security_group_ids" {
   description = "List of additional security group IDs to configure on the LBs"
 }
 
+variable "lb_disk_size" {
+  type        = number
+  default     = 20
+  description = "LB VM disk size"
+}
+
 variable "use_instancepools" {
   type        = bool
   description = "Use instance pools for node groups"


### PR DESCRIPTION
We keep 20GB disks as the default to make the change non-breaking.

Requires https://github.com/appuio/terraform-modules/pull/62 to be released as v6.6.0.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
