### PR TITLE
Fix logic for `initialize_topolvm_vg` for additional worker groups

### DIFF
--- a/worker.tf
+++ b/worker.tf
@@ -93,5 +93,5 @@ module "additional_worker" {
 
   use_instancepool = each.value.use_instancepool != null ? each.value.use_instancepool : var.use_instancepools
 
-  initialize_topolvm_vg = each.value.data_disk_size > 0 && each.value.initialize_topolvm_vg
+  initialize_topolvm_vg = each.value.data_disk_size > 0 && (each.value.initialize_topolvm_vg != null ? each.value.initialize_topolvm_vg : false)
 }


### PR DESCRIPTION
Gracefully handle omitted config field `initialize_topolvm_vg` for additional worker groups.

Fixes #111 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
