### PR TITLE
Ignore changes to `ssh_keys` after VM creation

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v7.0.1"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-exoscale?ref=v7.0.2"
 
   exoscale_domain_name = exoscale_domain.cluster.name
   cluster_network = {

--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -223,6 +223,7 @@ resource "exoscale_compute_instance" "nodes" {
       template_id,
       user_data,
       elastic_ip_ids,
+      ssh_keys,
     ]
   }
 }


### PR DESCRIPTION
Exoscale doesn't allow updating an instance's SSH keys after creation, so we add `ssh_keys` to `lifecycle.ignore_changes`.

The update of the vshn-lbaas-exoscale module to v7.0.2 makes the same change for the LB VMs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
